### PR TITLE
Update sidenav so pages are smaller

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,5 +1,3 @@
-{% assign sidebar = site.data.sidebars[page.sidebar].entries %}
-
 <ul id="mysidebar" class="nav">
   <li class="sidebarTitle">{{sidebar[0].product}} {{sidebar[0].version}}</li>
   {% for entry in sidebar %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,11 @@
 <head>
     {% include head.html %}
     <script>
-        $(document).ready(function() {
+        
+        fetch("sidebar-{{page.sidebar}}.html")
+        .then(resp => resp.text())
+        .then(html => document.getElementById("tg-sb-sidebar").innerHTML = html)
+        .then(function () {
             // Initialize navgoco with default options
             $("#mysidebar").navgoco({
                 caretHtml: '',
@@ -30,8 +34,7 @@
                 e.preventDefault();
                 $("#mysidebar").navgoco('toggle', true);
             });
-
-        });
+        })
 
     </script>
     <script>
@@ -83,7 +86,7 @@
         {% unless page.hide_sidebar %}
             <!-- Sidebar Column -->
             <div class="col-md-3" id="tg-sb-sidebar">
-                {% include sidebar.html %}
+                
             </div>
             {% assign content_col_size = "col-md-9" %}
         {% endunless %}

--- a/pages/sidebar-home_sidebar.md
+++ b/pages/sidebar-home_sidebar.md
@@ -1,0 +1,8 @@
+---
+layout: none
+permalink: sidebar-home_sidebar.html
+---
+
+{% assign sidebar = site.data.sidebars["home_sidebar"].entries %}
+
+{% include sidebar.html %}

--- a/pages/sidebar-mydoc_sidebar.md
+++ b/pages/sidebar-mydoc_sidebar.md
@@ -1,0 +1,8 @@
+---
+layout: none
+permalink: sidebar-mydoc_sidebar.html
+---
+
+{% assign sidebar = site.data.sidebars["mydoc_sidebar"].entries %}
+
+{% include sidebar.html %}

--- a/pages/sidebar-other.md
+++ b/pages/sidebar-other.md
@@ -1,0 +1,8 @@
+---
+layout: none
+permalink: sidebar-other.html
+---
+
+{% assign sidebar = site.data.sidebars["other"].entries %}
+
+{% include sidebar.html %}

--- a/pages/sidebar-product1_sidebar.md
+++ b/pages/sidebar-product1_sidebar.md
@@ -1,0 +1,8 @@
+---
+layout: none
+permalink: sidebar-product1_sidebar.html
+---
+
+{% assign sidebar = site.data.sidebars["product1_sidebar"].entries %}
+
+{% include sidebar.html %}

--- a/pages/sidebar-product2_sidebar.md
+++ b/pages/sidebar-product2_sidebar.md
@@ -1,0 +1,8 @@
+---
+layout: none
+permalink: sidebar-product2_sidebar.html
+---
+
+{% assign sidebar = site.data.sidebars["product2_sidebar"].entries %}
+
+{% include sidebar.html %}


### PR DESCRIPTION
https://github.com/SuLab/DrugMechDB/issues/593

Just uses fetch to fetch the side nav when page is opened instead of at jekyll build/compile time. This greatly reduces the size of compiled html files.

(Note: I'm not sure if I'm supposed to set the target branch as main or gh-pages)